### PR TITLE
Correct typo - docket to docker

### DIFF
--- a/number-one.code-workspace
+++ b/number-one.code-workspace
@@ -10,7 +10,7 @@
 		"recommendations": [
 			"ms-vscode.node-debug2",
 			"editorconfig.editorconfig",
-			"ms-azuretools.vscode-docket",
+			"ms-azuretools.vscode-docker",
 			"github.vscode-pull-request-github",
 		]
 	},


### PR DESCRIPTION
Corrected typo for extension in workspace.